### PR TITLE
Deprecate sipairs, spairs and snext

### DIFF
--- a/luarules/gadgets/unit_morph.lua
+++ b/luarules/gadgets/unit_morph.lua
@@ -995,8 +995,6 @@ end
 local gameFrame;
 local SYNCED = SYNCED
 local CallAsTeam = CallAsTeam
-local spairs = spairs
-local snext = snext
 
 local GetUnitTeam         = Spring.GetUnitTeam
 local GetUnitHeading      = Spring.GetUnitHeading
@@ -1128,7 +1126,7 @@ function gadget:Update()
   local frame = spGetGameFrame()
   if (frame>oldFrame) then
     oldFrame = frame
-    if snext(SYNCED.morphUnits) then
+    if next(SYNCED.morphUnits) then
       local useLuaUI_ = Script.LuaUI('MorphUpdate')
       if (useLuaUI_~=useLuaUI) then --//Update Callins on change
         drawProgress = not Script.LuaUI('MorphDrawProgress')
@@ -1142,7 +1140,7 @@ function gadget:Update()
           then readTeam = Script.ALL_ACCESS_TEAM
           else readTeam = GetLocalTeamID() end
         CallAsTeam({ ['read'] = readTeam }, function()
-          for unitID, morphData in spairs(SYNCED.morphUnits) do
+          for unitID, morphData in pairs(SYNCED.morphUnits) do
             if (unitID and morphData)and(IsUnitVisible(unitID)) then
               morphTable[unitID] = {progress=morphData.progress, into=morphData.def.into}
             end
@@ -1241,7 +1239,7 @@ function gadget:DrawWorld()
     if (not morphUnits) then return end
   end
 
-  if (not snext(morphUnits)) then
+  if (not next(morphUnits)) then
     return --//no morphs to draw
   end
 
@@ -1259,7 +1257,7 @@ function gadget:DrawWorld()
   end
 
   CallAsTeam({ ['read'] = readTeam }, function()
-    for unitID, morphData in spairs(morphUnits) do
+    for unitID, morphData in pairs(morphUnits) do
       if (unitID and morphData)and(IsUnitVisible(unitID)) then
         DrawMorphUnit(unitID, morphData,readTeam)
       end

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -48,9 +48,9 @@ if (System == nil) then
     --  Unsynced Utilities
     --
     SYNCED  = SYNCED,
-    snext   = snext,
-    spairs  = spairs,
-    sipairs = sipairs,
+    snext   = next, -- the following 3 are deprecated, but defined in case any legacy code uses them
+    spairs  = pairs,
+    sipairs = ipairs,
     
     --
     --  Standard libraries


### PR DESCRIPTION
These are no longer needed and are the same as regular pairs etc. Left them defined in case there's legacy code (e.g. in maps or something) using them.