### PR TITLE
Modrules: explicit `allowGroundUnitGravity`

### DIFF
--- a/gamedata/modrules.tdf
+++ b/gamedata/modrules.tdf
@@ -18,6 +18,7 @@
 {
 	allowUnitCollisionDamage=0;
 	allowUnitCollisionOverlap=0;
+	allowGroundUnitGravity=1;
 }
 
 [REPAIR]


### PR DESCRIPTION
This is already the implicit value, because it's the engine default, so there is no logic change, just safety against engine changes.